### PR TITLE
fix resolved relative urls for windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,12 @@ function getUrl(url) {
 	return url.match(/(['"]?)(.+)\1/)[2];
 }
 
+function normalizeUrl(url) {
+	return (path.sep === '\\') ? url.replace(/\\/g, '\/') : url;
+}
+
 function composeUrl(url) {
-	return 'url(' + url + ')';
+	return 'url(' + normalizeUrl(url) + ')';
 }
 
 // checks if file is not local
@@ -129,10 +133,6 @@ function processUrlRebase(dirname, url, to, options) {
 		}
 	}
 	copyAsset(absoluteAssetsPath, assetContents);
-
-	if (path.sep === '\\') {
-		relativeAssetsPath = relativeAssetsPath.replace(/\\/g, '\/');
-	}
 
 	return composeUrl(relativeAssetsPath);
 }

--- a/index.js
+++ b/index.js
@@ -130,5 +130,9 @@ function processUrlRebase(dirname, url, to, options) {
 	}
 	copyAsset(absoluteAssetsPath, assetContents);
 
+	if (path.sep === '\\') {
+		relativeAssetsPath = relativeAssetsPath.replace(/\\/g, '\/');
+	}
+
 	return composeUrl(relativeAssetsPath);
 }


### PR DESCRIPTION
Plugin uses module "path" for building result relative url. But on windows platform it use '//' as path separator. So on windows we get urls that can't be understand by browsers. 
