### PR TITLE
Fix example with promised way

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ var reporter = require('postcss-reporter');
 var css = fs.readFileSync("input.css", "utf8")
 
 // process css
-var output = postcss()
+postcss()
   .use(rebaser({
     assetsPath: "assets/imported", // new path for all assets
     relative: true // is assetsPath relative to .css position.
@@ -43,7 +43,9 @@ var output = postcss()
     from: "src/stylesheet/index.css"
     to: "dist/index.css"
   })
-  .css
+  .then(function (result) {
+    var output = result.css;
+  });
 ```
 #### Input `src/stylesheet/index.css`:
 ```css


### PR DESCRIPTION
`process().css` is just for debug and it shouldn't be used in production code. Also it shouldn't be an example of usage caz it can confuse users.
