### PR TITLE
Update dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
-sudo: false
+# https://docs.travis-ci.com/user/travis-lint
+
 language: node_js
+
 node_js:
-  - "stable"
-  - "0.12"
+  - 4
+
+install:
+  - npm install --ignore-scripts

--- a/package.json
+++ b/package.json
@@ -24,17 +24,18 @@
     "index.js"
   ],
   "dependencies": {
-    "mkdirp": "^0.5.0",
-    "postcss": "^5.0.12",
-    "postcss-value-parser": "^3.1.2",
+    "mkdirp": "^0.5.1",
+    "postcss": "^6.0.14",
+    "postcss-value-parser": "^3.3.0",
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "blue-tape": "^0.1.11",
-    "colortape": "^0.1.1",
-    "del": "^2.2.0",
-    "object-assign": "^4.0.1",
-    "path-exists": "^2.1.0"
+    "blue-tape": "^1.0.0",
+    "colortape": "^0.1.2",
+    "del": "^3.0.0",
+    "object-assign": "^4.1.1",
+    "path-exists": "^3.0.0",
+    "tape": "^4.8.0"
   },
   "scripts": {
     "test": "colortape test"


### PR DESCRIPTION
- Bumps major versions of postcss, blue-tape, del, and path-exists
- Resolves PostCSS compatibility issue (`Your current PostCSS version is 6.0.14, but postcss-assets-rebase uses 4.1.16...`)
- All tests remain functional